### PR TITLE
Remove leading space from returned versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,8 @@ runs:
           fi
         fi
       done
+      # Trim spaces.
+      VERSIONS=$(echo $VERSIONS | xargs)
       echo "::set-output name=versions::${VERSIONS}"
 
   - name: Find and Replace


### PR DESCRIPTION
**What this PR does / why we need it**:
PR https://github.com/portworx/action-update-base-images/pull/1 returned the versions in `old-version` output with a leading space which made the changelog generation fail later. This PR is fixing this.
