### PR TITLE
Fix condition in commit step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,21 +71,15 @@ runs:
       fi
 
       # Replace current versions with the new one for each file.
-      modifiedFiles=0
       for file in $BUILDAH_FILES
       do
         for current_version in $VERSIONS
         do
-          sed -i "s/$current_version/$REPLACE/gw /tmp/changes" $file
-          if [ -s /tmp/changes ]; then
-            modifiedFiles=$((modifiedFiles+1))
-          fi
+          sed -i "s/$current_version/$REPLACE/g" $file
         done
       done
-      echo "modifiedFiles=$modifiedFiles" >> $GITHUB_OUTPUT
 
   - name: Commit and Push
-    if: ${{ steps.replace.outputs.modifiedFiles > 0 }}
     uses: EndBug/add-and-commit@v7
     with:
       message: |

--- a/action.yml
+++ b/action.yml
@@ -78,7 +78,7 @@ runs:
         do
           sed -i "s/$current_version/$REPLACE/gw /tmp/changes" $file
           if [ -s /tmp/changes ]; then
-            ((modifiedFiles++))
+            modifiedFiles=$((modifiedFiles+1))
           fi
         done
       done

--- a/action.yml
+++ b/action.yml
@@ -71,13 +71,18 @@ runs:
       fi
 
       # Replace current versions with the new one for each file.
+      modifiedFiles=0
       for file in $BUILDAH_FILES
       do
         for current_version in $VERSIONS
         do
-          sed -i "s/$current_version/$REPLACE/g" $file
+          sed -i "s/$current_version/$REPLACE/gw /tmp/changes" $file
+          if [ -s /tmp/changes ]; then
+            ((modifiedFiles++))
+          fi
         done
       done
+      echo "modifiedFiles=$modifiedFiles" >> $GITHUB_OUTPUT
 
   - name: Commit and Push
     if: ${{ steps.replace.outputs.modifiedFiles > 0 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
PR https://github.com/portworx/action-update-base-images/pull/1 reimplemetned the `replace` step but it forgot to set `modifiedFiles` output, which is used as condition in the next step.